### PR TITLE
(#193) Fixed the navbar links on the student projects page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -64,9 +64,9 @@
         <div class="module-group right">
           <div class="module left">
             <ul class="menu">
-              <li><a href="#welcome">Welcome</a></li>
-              <li><a href="#mentors">Mentors</a></li>
-              <li><a href="#students">Students</a></li>
+              <li><a href="index.html#welcome">Welcome</a></li>
+              <li><a href="index.html#students">Students</a></li>
+              <li><a href="index.html#mentors">Mentors</a></li>
               <li><a href="projects.html">Projects</a></li>
               <li class="code-in-nav has-dropdown"><a href="https://codein.withgoogle.com/organizations/fossasia/" target="_blank">GCI</a>
                 <ul>


### PR DESCRIPTION
Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.

- [x] Included a Preview link and screenshot showning after and before the changes.
- [x] Included a description of change below.
- [x] Squashed the commits.

# Changes done in this Pull Request

- If your change will be reflected on the website, please provide a **Test-Link** (**Hint : `gh-pages`**)
- Fixes https://github.com/fossasia/gci18.fossasia.org/issues/193
- Preview Link: https://applec4t.github.io/gci18.fossasia.org/

## Description / Changes
Fixed the links bug on the student projects page causing them not to link back to the home page. Changed the header so that the links are precise and can link back to the main page on any sub-page.