### PR TITLE
making backtotop_button  to have same color theme

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -229,7 +229,7 @@ p.person-name {
 
 #backtotop_button {
   display: inline-block;
-  background-color: #1a86cc;
+  background-color: #e31d3b;
   width: 50px;
   height: 50px;
   text-align: center;


### PR DESCRIPTION
- [x] Included a Preview link and screenshot showing after and before the changes.
- [x] Included a description of the change below.
- [ ] Squashed the commits.

# Changes done in this Pull Request

- Adjusting `backtotop_button`  background according to website theme
- replacing `background-color` of `backtotop_button` to `#e31d3b` in `custom.css` file.


## Description / Changes
I have changed the background color of `backtotop_button` with the website color theme i.e; `#e31d3b`.

## Issue solve:
 Solved issue number #453 

## Screenshots :

  - After
  ![screenshot from 2018-11-22 19-46-51](https://user-images.githubusercontent.com/13312568/48908188-9d348900-ee8f-11e8-8766-399780d38adb.png)

 - Before
   ![screenshot from 2018-11-22 19-51-44](https://user-images.githubusercontent.com/13312568/48908406-21870c00-ee90-11e8-9cea-061f6f51ffe7.png)


- - - - - - - - - - - -
