### PR TITLE
Shows all students and more social-media icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 ---
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
+<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Raleway:300" />
 <a id="backtotop_button"></a>
 <section class="cover fullscreen image-slider slider-all-controls controls-inside parallax">
   <ul class="slides">
@@ -179,7 +180,7 @@ layout: default
   <div class="container" id="social_box">
     <div class="row mb80 mb-xs-0">
       <div class="col-md-8 col-md-offset-2 text-center">
-        <h1>Connect with FOSSASIA on Social Media</h1>
+        <h1 style='font-family:Raleway'>Connect with FOSSASIA on Social Media</h1>
         <p>Be sure to follow us on social media!</p>
         <div id="social_icons">
             <a href="https://www.facebook.com/fossasia/" class="ti-facebook lgi" target="_blank" rel="noopener noreferrer">
@@ -206,13 +207,13 @@ layout: default
             <a href="https://flickr.com/photos/fossasia" target="_blank" class="ti-flickr lgi" rel="noopener noreferrer">
                 <div>Flickr</div>
             </a>
-            <a href="https://gitter.im/fossasia/home" target="_blank" class="fab fa-gitter" rel="noopener noreferrer">
+            <a href="https://gitter.im/fossasia/home" target="_blank" class="fab fa-gitter lgi" rel="noopener noreferrer">
                 <div>Gitter</div>
             </a>
-            <a href="https://weibo.com/n/fossasia" target="_blank" class="fab fa-weibo" rel="noopener noreferrer">
+            <a href="https://weibo.com/n/fossasia" target="_blank" class="fab fa-weibo lgi" rel="noopener noreferrer">
                 <div>Weibo</div>
             </a>
-            <a href="https://fossasia-slack.herokuapp.com/" target="_blank" class="fab fa-slack" rel="noopener noreferrer">
+            <a href="https://fossasia-slack.herokuapp.com/" target="_blank" class="fab fa-slack lgi" rel="noopener noreferrer">
                 <div>Slack</div>
             </a>
             <a href="https://codein.withgoogle.com/organizations/fossasia/" target="_blank" class="ti-settings lgi" rel="noopener noreferrer">

--- a/index.html
+++ b/index.html
@@ -206,6 +206,15 @@ layout: default
             <a href="https://flickr.com/photos/fossasia" target="_blank" class="ti-flickr lgi" rel="noopener noreferrer">
                 <div>Flickr</div>
             </a>
+            <a href="https://gitter.im/fossasia/home" target="_blank" class="fab fa-gitter" rel="noopener noreferrer">
+                <div>Gitter</div>
+            </a>
+            <a href="https://weibo.com/n/fossasia" target="_blank" class="fab fa-weibo" rel="noopener noreferrer">
+                <div>Weibo</div>
+            </a>
+            <a href="https://fossasia-slack.herokuapp.com/" target="_blank" class="fab fa-slack" rel="noopener noreferrer">
+                <div>Slack</div>
+            </a>
             <a href="https://codein.withgoogle.com/organizations/fossasia/" target="_blank" class="ti-settings lgi" rel="noopener noreferrer">
                 <div>Code-In Page</div>
             </a>

--- a/index.html
+++ b/index.html
@@ -513,7 +513,7 @@ layout: default
     </div>
     <!-- end of row -->
     <div class="row">
-      {% for student in site.data.students limit:30 %}
+      {% for student in site.data.students limit:9999 %}
 
       <div class="col-xs-12 col-sm-3 col-md-3 col-lg-3 text-center">
         <div class="card single-mentor">


### PR DESCRIPTION
- [x] Included a Preview link and screenshot showing after and before the changes.
- [x] Included a description of the change below.

# Changes done in this Pull Request
- See https://kualeyi.github.io/gci18.fossasia.org
- Fixes #479, #481
- Comments on, probably fixes #462

## Description
This change will make the students all visible (#479) and the three requested social-media icons present (#481). I also note that the favicon of https://gci18.fossasia.org is F and _not a 'black dot', but the Google Code-in gear (!)_, so issue #462 is invalid.

## Screenshots:
### Before:
![image](https://user-images.githubusercontent.com/23028142/48970330-db73a900-f045-11e8-8a8a-988dfdfce938.png)
![image](https://user-images.githubusercontent.com/23028142/48970336-f7774a80-f045-11e8-8059-20eaa0b32bfd.png)

### After:
![image](https://user-images.githubusercontent.com/23028142/48970314-be3eda80-f045-11e8-9e82-eea983cb307c.png)
![image](https://user-images.githubusercontent.com/23028142/48970409-bb90b500-f046-11e8-87b3-c4edb7e6d93b.png)



- - - - - - - - - - - -
