### PR TITLE
Revert "Fixed the social media icons "

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
 <a id="backtotop_button"></a>
 <section class="cover fullscreen image-slider slider-all-controls controls-inside parallax">
   <ul class="slides">


### PR DESCRIPTION
Reverts fossasia/gci18.fossasia.org#493 because it was breaking the social media section
Current:
![image](https://user-images.githubusercontent.com/13624560/48975726-7cda1980-f09d-11e8-9b7a-205e8ae64838.png)
Before:
![image](https://user-images.githubusercontent.com/13624560/48975723-6df36700-f09d-11e8-94f6-91aa69daa0db.png)
