### PR TITLE
Fixed GCI icon spacing in navbar (#519)

### DIFF
--- a/css/_custom.scss
+++ b/css/_custom.scss
@@ -30,9 +30,10 @@
   background-image: url("https://raw.githubusercontent.com/fossasia/gci17.fossasia.org/gh-pages/img/gci-logo.png");
   background-size: contain;
   background-repeat: no-repeat;
-  padding: 0 16px;
+  padding: 0 2px 0 16px;
   padding-top: 0px;
   font-size: 1rem;
+  cursor: pointer;
 }
 
 .seperator {


### PR DESCRIPTION
<!-- Please read and understand everything below
**Do not delete any text other than where you are instructed to.** -->

<!-- **Students: If one of them is applicable to you. Please check it.** -->

<!-- Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.-->

- [x] Included a Preview link and screenshot showing after and before the changes.
- [x] Included a description of the change below.
- [x] Squashed the commits.

# Changes done in this Pull Request

<!-- If your change will be reflected on the website, please provide a Test Link **Hint : `master`** -->
- [Preview Link](https://niteshkumarniranjan.github.io/gci18.fossasia.org/)
<!-- If you fully fixed some issue, please insert the issue number after the #.
If you have not completely fixed an issue but only some part of it, then remove “Fixes #” and simply link the PR to the issue by writing '#<Issue Number>' -->
- Fixes #519 


## Description / Changes
GCI icon text spacing is too much making it look like two different components.


## Screenshots if any:
### Before:
![screenshot from 2018-11-26 23-08-03](https://user-images.githubusercontent.com/20199181/49031759-e60e7980-f1d0-11e8-9c70-df8b94db8752.png)
### After:
![screenshot from 2018-11-26 23-26-08](https://user-images.githubusercontent.com/20199181/49032492-b5c7da80-f1d2-11e8-812f-4a41dbf33f1c.png)



- - - - - - - - - - - -
<!-- [preview link url]: https://<github_username>.github.io/<name_of_repository> -->
<!-- [squash]:https://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git-->
<!--[squash2]https://davidwalsh.name/squash-commits-git-->
