### PR TITLE
Improves Instagram and Google+ icons in social-media section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+<link href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" rel="stylesheet" type="text/css" media="all"><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all">
 <a id="backtotop_button"></a>
 <section class="cover fullscreen image-slider slider-all-controls controls-inside parallax">
   <ul class="slides">
@@ -187,9 +188,9 @@ layout: default
           <a href="https://flickr.com/photos/fossasia" title="Flickr" target="_blank" class="ti-flickr lgi" rel="noopener"></a>
           <a href="https://www.facebook.com/fossasia/" title="Facebook" target="_blank" class="ti-facebook lgi" rel="noopener"></a>
           <a href="https://twitter.com/fossasia" title="Twitter" target="_blank" class="ti-twitter lgi" rel="noopener"></a>
-          <a href="https://www.instagram.com/fossasia/" title="Instagram" target="_blank" class="ti-instagram lgi" rel="noopener"></a>
+          <a href="https://www.instagram.com/fossasia/" title="Instagram" target="_blank" class="fab fa-instagram lgi" rel="noopener"></a>
           <a href="https://www.linkedin.com/groups/FOSSASIA-3762811" title="LinkedIn" target="_blank" class="ti-linkedin lgi" rel="noopener"></a>
-          <a href="https://plus.google.com/108920596016838318216" title="Google+" target="_blank" class="ti-google lgi" rel="noopener"></a>
+          <a href="https://plus.google.com/108920596016838318216" title="Google+" target="_blank" class="fab fa-google-plus-g lgi" rel="noopener"></a>
           <a href="https://codein.withgoogle.com/organizations/fossasia/" title="GCI" target="_blank" class="ti-settings lgi" rel="noopener"></a>
         </p>
       </div>


### PR DESCRIPTION
<!-- Please read and understand everything below
**Do not delete any text other than where you are instructed to.** -->

<!-- **Students: If one of them is applicable to you. Please check it.** -->

<!-- Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.-->

- [x] Included a Preview link and screenshot showing after and before the changes.
- [x] Included a description of the change below.
- [x] Squashed the commits.

# Changes done in this Pull Request
- Changes Instagram and Google+ icons to modern Font Awesome versions
<!-- If your change will be reflected on the website, please provide a Test Link **Hint : `master`** -->
- [Preview Link](https://kualeyi.github.io/gci18fossasiaorg)
<!-- If you fully fixed some issue, please insert the issue number after the #.
If you have not completely fixed an issue but only some part of it, then remove “Fixes #” and simply link the PR to the issue by writing '#<Issue Number>' -->
- Fixes #444


## Description
This change will put in up-to-date icons for Instagram and Google+ in the social-media section of the website in place of the old Themify ones, by having different inline CSS classes at the relevant anchors. It adds a link to an external resource, namely version 5.5.0 of Font Awesome, near the top of `index.html`.

## Screenshots if any:
### Before:
![image](https://user-images.githubusercontent.com/23028142/49130552-7ce15000-f30f-11e8-9702-f94cbcded77e.png)
### After:
![image](https://user-images.githubusercontent.com/23028142/49130617-bdd96480-f30f-11e8-8c9a-15ab5a19162d.png)

- - - - - - - - - - - -
<!-- [preview link url]: https://<github_username>.github.io/<name_of_repository> -->
<!-- [squash]:https://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git-->
<!--[squash2]https://davidwalsh.name/squash-commits-git-->
